### PR TITLE
Stub out initial endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Compiled class file
 *.class
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/url-shortener-service/build.gradle.kts
+++ b/url-shortener-service/build.gradle.kts
@@ -4,6 +4,7 @@ val logback_version: String by project
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ktor)
     alias(libs.plugins.conventionalCommits)
 }

--- a/url-shortener-service/gradle/libs.versions.toml
+++ b/url-shortener-service/gradle/libs.versions.toml
@@ -11,6 +11,9 @@ ktor-server-core-jvm = { module = "io.ktor:ktor-server-core-jvm", version.ref = 
 ktor-server-defaultHeaders = { module = "io.ktor:ktor-server-default-headers-jvm", version.ref = "ktorVersion" }
 ktor-server-callLogging = { module = "io.ktor:ktor-server-call-logging-jvm", version.ref = "ktorVersion" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktorVersion" }
+ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref = "ktorVersion" }
+ktor-server-contentNegotiation = { module = "io.ktor:ktor-server-content-negotiation-jvm", version.ref = "ktorVersion" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktorVersion" }
 ktor-server-tests = { module = "io.ktor:ktor-server-tests-jvm", version.ref = "ktorVersion" }
 
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlinVersion" }
@@ -22,10 +25,14 @@ ktor-server = [
     "ktor-server-core-jvm",
     "ktor-server-defaultHeaders",
     "ktor-server-callLogging",
-    "ktor-server-netty"
+    "ktor-server-netty",
+    "ktor-server-resources",
+    "ktor-server-contentNegotiation",
+    "ktor-serialization-json"
 ]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinVersion" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktorVersion" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinVersion" }
 conventionalCommits = { id = "it.nicolasfarabegoli.conventional-commits", version.ref = "conventionalCommitsPluginVersion" }

--- a/url-shortener-service/src/main/kotlin/dev/goobar/Application.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/Application.kt
@@ -1,21 +1,26 @@
 package dev.goobar
 
+import dev.goobar.data.environment.DeploymentEnvironment
+import dev.goobar.data.environment.DeploymentInfo
 import dev.goobar.plugins.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 
-fun main() {
-    embeddedServer(
-        Netty,
-        port = 8080,
-        host = "0.0.0.0",
-        module = Application::module
-    ).start(wait = true)
-}
+fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
 fun Application.module() {
     configureMonitoring()
     configureHTTP()
+    configureTypeSafeRouting()
     configureRouting()
 }
+
+val Application.deploymentInfo: DeploymentInfo
+    get() {
+        val envProperty = environment.config.property("ktor.environment")
+        val env = DeploymentEnvironment.valueOf(envProperty.getString().uppercase())
+        val revisionProperty = environment.config.property("ktor.revision").getString()
+
+        return DeploymentInfo(env, revisionProperty)
+    }

--- a/url-shortener-service/src/main/kotlin/dev/goobar/data/ShortenUrlRequestBody.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/data/ShortenUrlRequestBody.kt
@@ -1,0 +1,9 @@
+package dev.goobar.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShortenUrlRequestBody(
+    val url: String,
+    val description: String? = null
+)

--- a/url-shortener-service/src/main/kotlin/dev/goobar/data/ShortenedUrl.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/data/ShortenedUrl.kt
@@ -1,0 +1,11 @@
+package dev.goobar.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShortenedUrl(
+    val id: Long,
+    val url: String,
+    val urlKey: String,
+    val description: String? = null
+)

--- a/url-shortener-service/src/main/kotlin/dev/goobar/data/UrlRepository.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/data/UrlRepository.kt
@@ -1,0 +1,23 @@
+package dev.goobar.data
+
+/**
+ * Placeholder repository to simulate ADD/REMOVE operations
+ */
+object UrlRepository {
+
+    val data: MutableList<ShortenedUrl> = mutableListOf(
+        ShortenedUrl(
+            id = 0,
+            url = "https://ktor.io/docs/welcome.html",
+            urlKey = "welcome",
+            description = "Ktor Welcome Page"
+        ),
+        ShortenedUrl(
+            id = 1,
+            url = "https://goobar.dev/",
+            urlKey = "goobar",
+            description = null
+        ),
+    )
+
+}

--- a/url-shortener-service/src/main/kotlin/dev/goobar/data/environment/DeploymentEnvironment.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/data/environment/DeploymentEnvironment.kt
@@ -1,0 +1,11 @@
+package dev.goobar.data.environment
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class DeploymentEnvironment {
+    LOCAL,
+    DOCKER,
+    DEV,
+    PROD
+}

--- a/url-shortener-service/src/main/kotlin/dev/goobar/data/environment/DeploymentInfo.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/data/environment/DeploymentInfo.kt
@@ -1,0 +1,9 @@
+package dev.goobar.data.environment
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeploymentInfo(
+    val environment: DeploymentEnvironment,
+    val revision: String
+)

--- a/url-shortener-service/src/main/kotlin/dev/goobar/plugins/HTTP.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/plugins/HTTP.kt
@@ -1,9 +1,14 @@
 package dev.goobar.plugins
 
+import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.defaultheaders.*
 
 fun Application.configureHTTP() {
+    install(ContentNegotiation) {
+        json()
+    }
     install(DefaultHeaders) {
         header("X-Engine", "Ktor") // will send this header with each response
     }

--- a/url-shortener-service/src/main/kotlin/dev/goobar/plugins/Resources.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/plugins/Resources.kt
@@ -1,0 +1,9 @@
+package dev.goobar.plugins
+
+
+import io.ktor.server.application.*
+import io.ktor.server.resources.*
+
+fun Application.configureTypeSafeRouting() {
+    install(Resources)
+}

--- a/url-shortener-service/src/main/kotlin/dev/goobar/plugins/Routing.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/plugins/Routing.kt
@@ -1,13 +1,15 @@
 package dev.goobar.plugins
 
+import dev.goobar.resources.status
+import dev.goobar.resources.urlKey
+import dev.goobar.resources.urls
 import io.ktor.server.application.*
-import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
 fun Application.configureRouting() {
     routing {
-        get("/") {
-            call.respondText("Hello World!")
-        }
+        status()
+        urlKey()
+        urls()
     }
 }

--- a/url-shortener-service/src/main/kotlin/dev/goobar/resources/Status.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/resources/Status.kt
@@ -1,0 +1,19 @@
+package dev.goobar.resources
+
+import dev.goobar.deploymentInfo
+import io.ktor.http.*
+import io.ktor.resources.*
+import io.ktor.server.resources.get
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+
+@Resource("/status")
+data object Status
+
+fun Routing.status() {
+    get<Status> {
+        call.respond(HttpStatusCode.OK, call.application.deploymentInfo)
+    }
+}

--- a/url-shortener-service/src/main/kotlin/dev/goobar/resources/UrlKey.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/resources/UrlKey.kt
@@ -1,0 +1,23 @@
+package dev.goobar.resources
+
+import dev.goobar.data.UrlRepository
+import io.ktor.http.*
+import io.ktor.resources.*
+import io.ktor.server.application.*
+import io.ktor.server.resources.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+@Resource("/{urlKey}")
+data class UrlKey(val urlKey: String)
+
+fun Routing.urlKey() {
+    get<UrlKey> { resource ->
+        val shortenedUrl = UrlRepository.data.find { it.urlKey == resource.urlKey }
+
+        when (shortenedUrl) {
+            null -> call.respond(HttpStatusCode.NotFound)
+            else -> call.respondRedirect(shortenedUrl.url)
+        }
+    }
+}

--- a/url-shortener-service/src/main/kotlin/dev/goobar/resources/Urls.kt
+++ b/url-shortener-service/src/main/kotlin/dev/goobar/resources/Urls.kt
@@ -1,0 +1,40 @@
+package dev.goobar.resources
+
+import dev.goobar.data.ShortenUrlRequestBody
+import dev.goobar.data.ShortenedUrl
+import dev.goobar.data.UrlRepository
+import io.ktor.http.*
+import io.ktor.resources.*
+import io.ktor.server.application.*
+import io.ktor.server.resources.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import java.util.UUID
+
+@Resource("/urls")
+data object AllUrls {
+    @Resource("shorten")
+    data class Shorten(val parent: AllUrls = AllUrls)
+}
+
+fun Routing.urls() {
+
+    get<AllUrls> {
+        call.respond(HttpStatusCode.OK, UrlRepository.data)
+    }
+
+    post<AllUrls.Shorten, ShortenUrlRequestBody> { resource, body ->
+
+        val urlKey = UUID.randomUUID().toString()
+
+        val shortenedUrl = ShortenedUrl(
+            id = System.currentTimeMillis(),
+            url = body.url,
+            urlKey = urlKey,
+            description = body.description
+        )
+        UrlRepository.data.add(shortenedUrl)
+
+        call.respond(shortenedUrl)
+    }
+}

--- a/url-shortener-service/src/main/resources/application.conf
+++ b/url-shortener-service/src/main/resources/application.conf
@@ -1,0 +1,16 @@
+ktor {
+    environment = "local"
+    environment = ${?KTOR_ENV}
+
+    revision = "0"
+    revision = ${?K_REVISION}
+
+    application {
+        modules = [ dev.goobar.ApplicationKt.module ]
+    }
+
+    deployment {
+        port = 8080
+        host = "0.0.0.0"
+    }
+}


### PR DESCRIPTION
Closes #7 

- Adds content negotiation and kotlinx.serialization
- Stubs out models for representing shortened urls and shorten request bodies
- Adds `GET /status` endpoint to server as a "health check" endpoint that includes deployment env and revision info
- Adds `GET /urls` endpoint to return all saved urls
- Adds `GET /urls/{urlKey}` endpoint to redirect to the full url corresponding to the passed urlKey
- Adds `POST /urls/shorten` endpoint to save/shorten a new url